### PR TITLE
Desanitizing values inside an array doesn't appear to work

### DIFF
--- a/spec/desanitize_executor_spec.rb
+++ b/spec/desanitize_executor_spec.rb
@@ -52,6 +52,17 @@ describe Desanitizer::DesanitizeExecutor do
     end
   end
 
+  context "when given a file with a sanitized array" do
+    let(:original_file) { "#{tmp_dir}/sanitized_manifest_with_array.yml" }
+
+    it 'replaces mustache keys inside arrays with the values from secrets file' do
+      Desanitizer::DesanitizeExecutor.execute(original_file, tmp_dir)
+      desanitized_yml = File.read(File.expand_path("#{tmp_dir}/manifest_with_array.yml"))
+      expected_yml  = File.read(File.expand_path(original_file))
+      expect(expected_yml).to eq(desanitized_yml)
+    end
+  end
+
   context "when given a multiline file" do
     let(:original_file) { "#{tmp_dir}/sanitized_manifest_multiline.yml" }
 

--- a/spec/fixture/manifest_with_array.yml
+++ b/spec/fixture/manifest_with_array.yml
@@ -1,0 +1,5 @@
+---
+bla:
+  foo:
+    bar_secret_key_array:
+    - bar_secret_value

--- a/spec/fixture/sanitized_manifest_with_array.yml
+++ b/spec/fixture/sanitized_manifest_with_array.yml
@@ -1,0 +1,4 @@
+bla:
+  foo:
+    bar_secret_key_array:
+    - {{bla_foo_bar_secret_key}}

--- a/spec/fixture/secrets-sanitized_manifest_with_array.json
+++ b/spec/fixture/secrets-sanitized_manifest_with_array.json
@@ -1,0 +1,3 @@
+{
+  "bla_foo_bar_secret_key": "bar_secret_value"
+}


### PR DESCRIPTION
Given:

```yaml
bla:
  foo:
    bar_secret_key_array:
    - {{bla_foo_bar_secret_key}} 
```

and secrets

```json
{
  "bla_foo_bar_secret_key": "bar_secret_value"
} 
```

desanitizing doesn't replace `{{bla_foo_bar_secret_key}}`

Here is a failing test demonstrating the issue

```
  1) Desanitizer::DesanitizeExecutor when given a file with a sanitized array replaces mustache keys inside arrays with the values from secrets file
     Failure/Error: expect(expected_yml).to eq(desanitized_yml)

       expected: "---\nbla:\n  foo:\n    bar_secret_key_array:\n    - bar_secret_value\n"
            got: "---\nbla:\n  foo:\n    bar_secret_key_array:\n    - ? bla_foo_bar_secret_key: \n      : \n"

       (compared using ==)

       Diff:
       @@ -2,5 +2,6 @@
        bla:
          foo:
            bar_secret_key_array:
       -    - bar_secret_value
       +    - ? bla_foo_bar_secret_key:
       +      :
```

Please can you help me make the test pass if this is indeed incorrect behaviour