### PR TITLE
Expose replace hook

### DIFF
--- a/lib/sanitizer/mustache_replacer.rb
+++ b/lib/sanitizer/mustache_replacer.rb
@@ -36,7 +36,12 @@ module Sanitizer
           end
 
           @secrets[path] = value
-          focus[hierarchy.last] = "{{#{path}}}" #replace with mustache syntax like '{{ properties_aws_key }}'
+          if block_given?
+            override_path = yield(value, path)
+            focus[hierarchy.last] = override_path
+          else
+            focus[hierarchy.last] = "{{#{path}}}" # replace with mustache syntax like '{{ properties_aws_key }}'
+          end
         end
       end
     end

--- a/lib/sanitizer/sanitize_executor.rb
+++ b/lib/sanitizer/sanitize_executor.rb
@@ -6,7 +6,8 @@ module Sanitizer
       manifest_path: nil,
       pattern_file: nil,
       secrets_path: nil,
-      logger: Logger.new(STDERR)
+      logger: Logger.new(STDERR),
+      &block
     )
 
       manifest = YAML.load_file(manifest_path)
@@ -29,7 +30,11 @@ module Sanitizer
       replacer = Sanitizer::MustacheReplacer.new(config_pattern, manifest, existing_secrets, logger)
 
       Sanitizer::YamlTraverser.traverse(manifest) do |k, v, hierarchy|
-        replacer.replace(k, v, hierarchy)
+        unless block_given?
+          replacer.replace(k, v, hierarchy)
+        else
+          replacer.replace(k, v, hierarchy, &block)
+        end
       end
 
       File.open(manifest_path, 'w') do |file|

--- a/spec/mustache_replacer_spec.rb
+++ b/spec/mustache_replacer_spec.rb
@@ -68,4 +68,26 @@ describe Sanitizer::MustacheReplacer do
     expect(replacer.manifest_yaml).to eql("---\nspiff_key: \"(( spiff_value ))\"\n")
 
   end
+
+  describe 'iterator on replace' do
+    it 'should expose the current value and path' do
+      observed_value = nil
+      observed_path = nil
+      replacer = Sanitizer::MustacheReplacer.new(patterns, sanitize_hash, {}, Logger.new(nil))
+      replacer.replace('some_key', 'some_value', ['some_key']) do |value, path|
+        observed_value = value
+        observed_path = path
+      end
+      expect(observed_value).to eq('some_value')
+      expect(observed_path).to eq('some_key')
+    end
+
+    it 'should replace using the value returned from the iterator' do
+      replacer = Sanitizer::MustacheReplacer.new(patterns, sanitize_hash, {}, Logger.new(nil))
+      replacer.replace('some_key', 'some_value', ['some_key']) do |_, path|
+        "((#{path}))"
+      end
+      expect(replacer.manifest_yaml).to eql("---\nsome_key: \"((some_key))\"\n")
+    end
+  end
 end

--- a/spec/sanitize_executor_spec.rb
+++ b/spec/sanitize_executor_spec.rb
@@ -118,4 +118,24 @@ describe Sanitizer::SanitizeExecutor do
 
 
   end
+
+  context 'when given a block' do
+    it 'should expose access to each value being replaced and its path' do
+      FileUtils.rm("#{tmp_dir}/secrets-manifest_1.json")
+
+      observed_values = []
+      observed_paths  = []
+      Sanitizer::SanitizeExecutor.execute(manifest_path: "#{tmp_dir}/manifest_1.yml",
+                                          pattern_file: default_config_path,
+                                          secrets_path: tmp_dir,
+                                          logger: Logger.new(nil)) do |value, path|
+        observed_values << value
+        observed_paths  << path
+      end
+      expect(observed_values).to include('bar_secret_value')
+      expect(observed_paths).to include('bla_foo_bar_secret_key')
+    end
+  end
+
+
 end


### PR DESCRIPTION
Expose a hook on the `MustacheReplacer` and `SanitizeExecutor` that allows programmatic access to the `value` and `path` during the replacing process.

Please let me know if I can/should do a version bump as part of this PR. If you accept the change I'd love to start using it right away! 😸 